### PR TITLE
Auth/UI and profile

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -8,7 +8,10 @@ import { routes } from './app.routes';
 // sur toutes les requêtes vers le back quand l'utilisateur est connecté.
 const authInterceptor: HttpInterceptorFn = (req, next) => {
   const token = localStorage.getItem('token');
-  if (token) {
+  // On n'ajoute pas le token sur les routes d'authentification
+  // (login / register n'ont pas besoin d'être authentifiées)
+  const isAuthRoute = req.url.includes('/api/auth/');
+  if (token && !isAuthRoute) {
     req = req.clone({ setHeaders: { Authorization: `Bearer ${token}` } });
   }
   return next(req);

--- a/src/app/catalogue/catalogue.css
+++ b/src/app/catalogue/catalogue.css
@@ -28,6 +28,7 @@
   border-radius: 6px;
   font-size: 0.95rem;
   background-color: var(--bg-input);
+  color: var(--text-primary);
   box-sizing: border-box;
 }
 
@@ -50,6 +51,7 @@
   border-radius: 6px;
   font-size: 0.9rem;
   background-color: var(--bg-input);
+  color: var(--text-primary);
   cursor: pointer;
 }
 
@@ -238,6 +240,7 @@
   padding: 8px 14px;
   border: 1px solid var(--border-input);
   background: var(--bg-carte);
+  color: var(--text-primary);
   border-radius: 6px;
   cursor: pointer;
   font-size: 0.9rem;

--- a/src/app/connexion/connexion.css
+++ b/src/app/connexion/connexion.css
@@ -20,15 +20,18 @@ h2 {
 }
 
 .formulaire {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
   width: 100%;
   max-width: 420px;
   background: var(--bg-carte);
   border-radius: 16px;
   padding: 40px 48px;
   box-shadow: var(--ombre-carte);
+}
+
+.formulaire form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
 .champ {

--- a/src/app/connexion/connexion.html
+++ b/src/app/connexion/connexion.html
@@ -2,54 +2,57 @@
   <h2>Connexion</h2>
 
   <section class="formulaire" aria-label="Formulaire de connexion">
+    <form (ngSubmit)="onSubmit()" #loginForm="ngForm" novalidate>
 
-    <div class="champ">
-      <label for="email">Email <span class="requis">*</span></label>
-      <input id="email" type="email"
-             [(ngModel)]="email"
-             name="email"
-             placeholder="Entrez votre email"
-             autocomplete="email"
-             aria-required="true"
-             aria-describedby="erreur-msg"
-             required />
-    </div>
-
-    <div class="champ">
-      <label for="mdp">Mot de passe <span class="requis">*</span></label>
-      <div class="input-mdp" role="group" aria-label="Mot de passe">
-        <input id="mdp"
-               [type]="showPassword ? 'text' : 'password'"
-               [(ngModel)]="motDePasse"
-               name="motDePasse"
-               placeholder="Entrez votre mot de passe"
-               autocomplete="current-password"
+      <div class="champ">
+        <label for="email">Email <span class="requis">*</span></label>
+        <input id="email" type="email"
+               [(ngModel)]="email"
+               name="email"
+               placeholder="Entrez votre email"
+               autocomplete="username"
                aria-required="true"
                aria-describedby="erreur-msg"
                required />
-
-        <button type="button"
-                (click)="showPassword = !showPassword"
-                [attr.aria-label]="showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'">
-          &#128065;
-        </button>
       </div>
-    </div>
 
-    @if (erreur) {
-      <p class="erreur" id="erreur-msg" role="alert">Mauvais email ou mot de passe</p>
-    }
+      <div class="champ">
+        <label for="mdp">Mot de passe <span class="requis">*</span></label>
+        <div class="input-mdp" role="group" aria-label="Mot de passe">
+          <input id="mdp"
+                 [type]="showPassword ? 'text' : 'password'"
+                 [(ngModel)]="motDePasse"
+                 name="motDePasse"
+                 placeholder="Entrez votre mot de passe"
+                 autocomplete="current-password"
+                 aria-required="true"
+                 aria-describedby="erreur-msg"
+                 required />
 
-    <p class="legende">* Champs obligatoires</p>
+          <button type="button"
+                  tabindex="-1"
+                  (click)="showPassword = !showPassword"
+                  [attr.aria-label]="showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'">
+            &#128065;
+          </button>
+        </div>
+      </div>
 
-    <button class="btn-bleu" (click)="onSubmit()" aria-label="Se connecter">
-      Se connecter
-    </button>
+      @if (erreur) {
+        <p class="erreur" id="erreur-msg" role="alert">Mauvais email ou mot de passe</p>
+      }
 
-    <div class="liens">
-      <a routerLink="/inscription">Créer un compte</a>
-      <a href="#">Demander à réinitialiser mot de passe</a>
-    </div>
+      <p class="legende">* Champs obligatoires</p>
 
+      <button type="submit" class="btn-bleu" aria-label="Se connecter">
+        Se connecter
+      </button>
+
+      <div class="liens">
+        <a routerLink="/inscription">Créer un compte</a>
+        <a href="#">Demander à réinitialiser mot de passe</a>
+      </div>
+
+    </form>
   </section>
 </main>

--- a/src/app/inscription/inscription.css
+++ b/src/app/inscription/inscription.css
@@ -20,15 +20,18 @@ h2 {
 }
 
 .formulaire {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
   width: 100%;
   max-width: 560px;
   background: var(--bg-carte);
   border-radius: 16px;
   padding: 40px 48px;
   box-shadow: var(--ombre-carte);
+}
+
+.formulaire form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
 .champ-horizontal {

--- a/src/app/inscription/inscription.html
+++ b/src/app/inscription/inscription.html
@@ -2,6 +2,7 @@
   <h2>Inscription</h2>
 
   <section class="formulaire" aria-label="Formulaire d'inscription">
+    <form (ngSubmit)="onSubmit()" #registerForm="ngForm" novalidate>
 
     <div class="champ-horizontal">
       <label for="nom">Nom <span class="requis">*</span></label>
@@ -64,6 +65,7 @@
                aria-required="true"
                required />
         <button type="button"
+                tabindex="-1"
                 (click)="showPassword = !showPassword"
                 [attr.aria-label]="showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'">
           &#128065;
@@ -83,6 +85,7 @@
                aria-required="true"
                required />
         <button type="button"
+                tabindex="-1"
                 (click)="showConfirm = !showConfirm"
                 [attr.aria-label]="showConfirm ? 'Masquer la confirmation' : 'Afficher la confirmation'">
           &#128065;
@@ -108,7 +111,7 @@
 
     <p class="legende">* Champs obligatoires</p>
 
-    <button class="btn-bleu" (click)="onSubmit()" aria-label="Créer mon compte">
+    <button type="submit" class="btn-bleu" aria-label="Créer mon compte">
       Créer compte
     </button>
 
@@ -116,5 +119,6 @@
       <a routerLink="/connexion">Retour connexion</a>
     </div>
 
+    </form>
   </section>
 </main>

--- a/src/app/models/update-user-request.model.ts
+++ b/src/app/models/update-user-request.model.ts
@@ -1,0 +1,9 @@
+export interface UpdateUserRequest {
+  email: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+  // requis par le back même si inchangé — envoyer chaîne vide si pas de changement de mot de passe
+  oldPassword: string;
+  password: string;
+}

--- a/src/app/models/user-response.model.ts
+++ b/src/app/models/user-response.model.ts
@@ -1,0 +1,9 @@
+export interface UserResponse {
+  id: number;
+  email: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+  role: string;
+  active: boolean;
+}

--- a/src/app/models/user-update-response.model.ts
+++ b/src/app/models/user-update-response.model.ts
@@ -1,0 +1,10 @@
+export interface UserUpdateResponse {
+  email: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+  role: string;
+  // Nouveau JWT retourné par le back après mise à jour
+  // Nécessaire si l'email a changé : le token doit être rafraîchi car il contient l'email comme "sub"
+  token: string;
+}

--- a/src/app/profil/profil.css
+++ b/src/app/profil/profil.css
@@ -1,0 +1,206 @@
+:host {
+  display: block;
+  width: 100%;
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  min-height: calc(100vh - 57px);
+  padding: 60px 20px;
+}
+
+h2 {
+  font-size: 22px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+/* ── Carte générique ── */
+.carte {
+  width: 100%;
+  max-width: 600px;
+  background: var(--bg-carte);
+  border-radius: 16px;
+  padding: 32px 40px;
+  box-shadow: var(--ombre-carte);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+h3 {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--border-input);
+  padding-bottom: 12px;
+}
+
+/* ── Grille 2 colonnes pour les champs infos ── */
+.grille {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.champ {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-label);
+}
+
+input[type="text"],
+input[type="email"],
+input[type="tel"],
+input[type="password"] {
+  border: 1px solid var(--border-input);
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 14px;
+  width: 100%;
+  background-color: var(--bg-input);
+  color: var(--text-primary);
+  transition: border-color 0.2s, background-color 0.2s;
+}
+
+/* Champ désactivé (mode lecture) : légèrement différent pour signaler la non-édition */
+input:disabled {
+  opacity: 0.75;
+  cursor: default;
+}
+
+input:not(:disabled):focus {
+  outline: none;
+  border-color: var(--border-focus);
+  background-color: var(--bg-input-focus);
+}
+
+.requis {
+  color: var(--couleur-erreur);
+  margin-left: 2px;
+}
+
+/* ── Boutons inline (sauvegarder / annuler) ── */
+.actions-edition {
+  display: flex;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+/* ── Actions principales (modifier / mdp / supprimer) ── */
+.actions-principales {
+  gap: 12px;
+}
+
+/* ── Boutons ── */
+.btn-bleu {
+  background-color: var(--couleur-primaire);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 11px 20px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  flex: 1;
+  transition: background-color 0.2s, transform 0.1s;
+}
+.btn-bleu:hover  { background-color: var(--couleur-primaire-hover); }
+.btn-bleu:active { transform: scale(0.99); }
+
+.btn-neutre {
+  background-color: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-input);
+  border-radius: 8px;
+  padding: 11px 20px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  flex: 1;
+  transition: background-color 0.2s;
+}
+.btn-neutre:hover { background-color: var(--bg-input-focus); }
+
+.btn-danger {
+  background-color: #dc2626;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 11px 20px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  flex: 1;
+  transition: background-color 0.2s;
+}
+.btn-danger:hover { background-color: #b91c1c; }
+
+/* ── Zone de confirmation suppression ── */
+.zone-confirmation {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: var(--bg-erreur);
+  border: 1px solid var(--border-erreur);
+  border-radius: 10px;
+  padding: 16px;
+  font-size: 14px;
+  color: var(--couleur-erreur);
+}
+
+/* ── Messages retour ── */
+.succes {
+  font-size: 14px;
+  color: #16a34a;
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 8px;
+  padding: 10px 16px;
+  width: 100%;
+  max-width: 600px;
+  text-align: center;
+}
+
+.erreur {
+  font-size: 14px;
+  color: var(--couleur-erreur);
+  background: var(--bg-erreur);
+  border: 1px solid var(--border-erreur);
+  border-radius: 8px;
+  padding: 10px 16px;
+  width: 100%;
+  max-width: 600px;
+  text-align: center;
+}
+
+.chargement {
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+/* ── Responsive ── */
+@media (max-width: 600px) {
+  .carte {
+    padding: 24px 20px;
+  }
+
+  .grille {
+    grid-template-columns: 1fr;
+  }
+
+  .actions-edition {
+    flex-direction: column;
+  }
+}

--- a/src/app/profil/profil.css
+++ b/src/app/profil/profil.css
@@ -18,7 +18,6 @@ h2 {
   color: var(--text-secondary);
 }
 
-/* ── Carte générique ── */
 .carte {
   width: 100%;
   max-width: 600px;
@@ -41,7 +40,6 @@ h3 {
   padding-bottom: 12px;
 }
 
-/* ── Grille 2 colonnes pour les champs infos ── */
 .grille {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -91,19 +89,16 @@ input:not(:disabled):focus {
   margin-left: 2px;
 }
 
-/* ── Boutons inline (sauvegarder / annuler) ── */
 .actions-edition {
   display: flex;
   gap: 12px;
   margin-top: 4px;
 }
 
-/* ── Actions principales (modifier / mdp / supprimer) ── */
 .actions-principales {
   gap: 12px;
 }
 
-/* ── Boutons ── */
 .btn-bleu {
   background-color: var(--couleur-primaire);
   color: #fff;
@@ -147,7 +142,6 @@ input:not(:disabled):focus {
 }
 .btn-danger:hover { background-color: #b91c1c; }
 
-/* ── Zone de confirmation suppression ── */
 .zone-confirmation {
   display: flex;
   flex-direction: column;
@@ -160,7 +154,6 @@ input:not(:disabled):focus {
   color: var(--couleur-erreur);
 }
 
-/* ── Messages retour ── */
 .succes {
   font-size: 14px;
   color: #16a34a;

--- a/src/app/profil/profil.html
+++ b/src/app/profil/profil.html
@@ -3,7 +3,6 @@
 
   @if (utilisateur) {
 
-    <!-- ── Informations personnelles ── -->
     <section class="carte" aria-label="Informations personnelles">
       <h3>Informations Personnelles</h3>
 
@@ -62,7 +61,6 @@
       </form>
     </section>
 
-    <!-- ── Changement de mot de passe (affiché à la demande) ── -->
     @if (modeMotDePasse) {
       <section class="carte" aria-label="Changement de mot de passe">
         <h3>Changer le mot de passe</h3>
@@ -107,7 +105,6 @@
       </section>
     }
 
-    <!-- ── Messages de retour globaux ── -->
     @if (messageSucces) {
       <p class="succes" role="status">{{ messageSucces }}</p>
     }
@@ -115,7 +112,6 @@
       <p class="erreur" role="alert">{{ messageErreur }}</p>
     }
 
-    <!-- ── Actions ── -->
     <section class="carte actions-principales" aria-label="Actions du compte">
       <h3>Actions</h3>
 

--- a/src/app/profil/profil.html
+++ b/src/app/profil/profil.html
@@ -1,1 +1,150 @@
-<p>profil works!</p>
+<main class="page">
+  <h2>Profil Utilisateur</h2>
+
+  @if (utilisateur) {
+
+    <!-- ── Informations personnelles ── -->
+    <section class="carte" aria-label="Informations personnelles">
+      <h3>Informations Personnelles</h3>
+
+      <form (ngSubmit)="sauvegarderProfil()" #profilForm="ngForm" novalidate>
+        <div class="grille">
+
+          <div class="champ">
+            <label for="email">Email</label>
+            <input id="email" type="email"
+                   [(ngModel)]="form.email"
+                   name="email"
+                   autocomplete="email"
+                   [disabled]="!modeEdition"
+                   required />
+          </div>
+
+          <div class="champ">
+            <label for="prenom">Prénom</label>
+            <input id="prenom" type="text"
+                   [(ngModel)]="form.firstName"
+                   name="firstName"
+                   autocomplete="given-name"
+                   [disabled]="!modeEdition"
+                   required />
+          </div>
+
+          <div class="champ">
+            <label for="nom">Nom</label>
+            <input id="nom" type="text"
+                   [(ngModel)]="form.lastName"
+                   name="lastName"
+                   autocomplete="family-name"
+                   [disabled]="!modeEdition"
+                   required />
+          </div>
+
+          <div class="champ">
+            <label for="telephone">Téléphone</label>
+            <input id="telephone" type="tel"
+                   [(ngModel)]="form.phone"
+                   name="phone"
+                   autocomplete="tel"
+                   [disabled]="!modeEdition" />
+          </div>
+
+        </div>
+
+        <!-- Boutons visibles uniquement en mode édition -->
+        @if (modeEdition) {
+          <div class="actions-edition">
+            <button type="submit" class="btn-bleu">Sauvegarder</button>
+            <button type="button" class="btn-neutre" (click)="annulerEdition()">Annuler</button>
+          </div>
+        }
+
+      </form>
+    </section>
+
+    <!-- ── Changement de mot de passe (affiché à la demande) ── -->
+    @if (modeMotDePasse) {
+      <section class="carte" aria-label="Changement de mot de passe">
+        <h3>Changer le mot de passe</h3>
+
+        <form (ngSubmit)="changerMotDePasse()" #mdpFormRef="ngForm" novalidate>
+          <div class="champ">
+            <label for="ancienMdp">Ancien mot de passe <span class="requis">*</span></label>
+            <input id="ancienMdp" type="password"
+                   [(ngModel)]="mdpForm.ancienMotDePasse"
+                   name="ancienMotDePasse"
+                   autocomplete="current-password"
+                   required />
+          </div>
+
+          <div class="champ">
+            <label for="nouveauMdp">Nouveau mot de passe <span class="requis">*</span></label>
+            <input id="nouveauMdp" type="password"
+                   [(ngModel)]="mdpForm.nouveauMotDePasse"
+                   name="nouveauMotDePasse"
+                   autocomplete="new-password"
+                   required />
+          </div>
+
+          <div class="champ">
+            <label for="confirmMdp">Confirmer le nouveau mot de passe <span class="requis">*</span></label>
+            <input id="confirmMdp" type="password"
+                   [(ngModel)]="mdpForm.confirmation"
+                   name="confirmation"
+                   autocomplete="new-password"
+                   required />
+          </div>
+
+          @if (messageErreurMdp) {
+            <p class="erreur" role="alert">{{ messageErreurMdp }}</p>
+          }
+
+          <div class="actions-edition">
+            <button type="submit" class="btn-bleu">Confirmer</button>
+            <button type="button" class="btn-neutre" (click)="modeMotDePasse = false">Annuler</button>
+          </div>
+        </form>
+      </section>
+    }
+
+    <!-- ── Messages de retour globaux ── -->
+    @if (messageSucces) {
+      <p class="succes" role="status">{{ messageSucces }}</p>
+    }
+    @if (messageErreur) {
+      <p class="erreur" role="alert">{{ messageErreur }}</p>
+    }
+
+    <!-- ── Actions ── -->
+    <section class="carte actions-principales" aria-label="Actions du compte">
+      <h3>Actions</h3>
+
+      @if (!modeEdition) {
+        <button class="btn-bleu" (click)="activerEdition()">Modifier le profil</button>
+      }
+
+      <button class="btn-neutre" (click)="modeMotDePasse = !modeMotDePasse">
+        {{ modeMotDePasse ? 'Annuler le changement de mot de passe' : 'Changer le mot de passe' }}
+      </button>
+
+      <!-- Suppression avec confirmation inline -->
+      @if (!confirmerSuppression) {
+        <button class="btn-danger" (click)="confirmerSuppression = true">Supprimer mon compte</button>
+      } @else {
+        <div class="zone-confirmation" role="alertdialog" aria-label="Confirmation de suppression">
+          <p>Cette action est irréversible. Confirmer la suppression ?</p>
+          <div class="actions-edition">
+            <button class="btn-danger" (click)="supprimerCompte()">Oui, supprimer</button>
+            <button class="btn-neutre" (click)="confirmerSuppression = false">Annuler</button>
+          </div>
+        </div>
+      }
+
+    </section>
+
+  } @else if (!messageErreur) {
+    <!-- Chargement en cours -->
+    <p class="chargement">Chargement du profil…</p>
+  }
+
+</main>

--- a/src/app/profil/profil.ts
+++ b/src/app/profil/profil.ts
@@ -1,12 +1,140 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { UserService } from '../services/user.service';
+import { UserResponse } from '../models/user-response.model';
 
 @Component({
   selector: 'app-profil',
-  imports: [],
+  standalone: true,
+  imports: [FormsModule],
   templateUrl: './profil.html',
-  styleUrl: './profil.css',
-  template: '<p>Page Profil — à venir</p>'
+  styleUrl: './profil.css'
 })
-export class Profil {
+export class Profil implements OnInit {
 
+  // Données affichées dans le formulaire
+  utilisateur: UserResponse | null = null;
+  userId: number | null = null;
+
+  // Champs du formulaire d'édition (copie des données pour ne pas modifier l'affichage en direct)
+  form = { email: '', firstName: '', lastName: '', phone: '' };
+
+  // Champs du formulaire de changement de mot de passe
+  mdpForm = { ancienMotDePasse: '', nouveauMotDePasse: '', confirmation: '' };
+
+  // États d'affichage
+  modeEdition = false;
+  modeMotDePasse = false;
+  confirmerSuppression = false;
+
+  // Messages retour utilisateur
+  messageSucces = '';
+  messageErreur = '';
+  messageErreurMdp = '';
+
+  constructor(private userService: UserService, private router: Router) {}
+
+  ngOnInit(): void {
+    this.chargerProfil();
+  }
+
+  chargerProfil(): void {
+    // getMe() utilise le token JWT via l'intercepteur pour identifier l'utilisateur côté back
+    this.userService.getMe().subscribe({
+      next: (data) => {
+        this.utilisateur = data;
+        this.userId = data.id;
+        // On initialise le formulaire avec les données reçues
+        this.form = {
+          email: data.email,
+          firstName: data.firstName,
+          lastName: data.lastName,
+          phone: data.phone ?? ''
+        };
+      },
+      error: () => {
+        // Si le token est invalide ou expiré, le back renvoie 401/403 → retour connexion
+        this.router.navigate(['/connexion']);
+      }
+    });
+  }
+
+  activerEdition(): void {
+    this.modeEdition = true;
+    this.messageSucces = '';
+    this.messageErreur = '';
+  }
+
+  annulerEdition(): void {
+    // Remet le formulaire à l'état initial sans sauvegarder
+    if (this.utilisateur) {
+      this.form = {
+        email: this.utilisateur.email,
+        firstName: this.utilisateur.firstName,
+        lastName: this.utilisateur.lastName,
+        phone: this.utilisateur.phone ?? ''
+      };
+    }
+    this.modeEdition = false;
+  }
+
+  sauvegarderProfil(): void {
+    this.userService.updateUser({
+      ...this.form,
+      // Pas de changement de mot de passe ici → chaînes vides
+      oldPassword: '',
+      password: ''
+    }).subscribe({
+      next: (data) => {
+        // Le back renvoie un nouveau token — on le remplace dans le localStorage
+        // pour que les prochains appels (dont GET /users/my) utilisent le bon email
+        localStorage.setItem('token', data.token);
+        this.utilisateur = { ...this.utilisateur!, ...data };
+        this.modeEdition = false;
+        this.messageSucces = 'Profil mis à jour avec succès.';
+        this.messageErreur = '';
+      },
+      error: () => {
+        this.messageErreur = 'Erreur lors de la mise à jour du profil.';
+      }
+    });
+  }
+
+  changerMotDePasse(): void {
+    if (this.mdpForm.nouveauMotDePasse !== this.mdpForm.confirmation) {
+      this.messageErreurMdp = 'Les mots de passe ne correspondent pas.';
+      return;
+    }
+    this.userService.updateUser({
+      ...this.form,
+      oldPassword: this.mdpForm.ancienMotDePasse,
+      password: this.mdpForm.nouveauMotDePasse
+    }).subscribe({
+      next: (data) => {
+        // Nouveau token après changement de mot de passe aussi
+        localStorage.setItem('token', data.token);
+        this.modeMotDePasse = false;
+        this.mdpForm = { ancienMotDePasse: '', nouveauMotDePasse: '', confirmation: '' };
+        this.messageSucces = 'Mot de passe modifié avec succès.';
+        this.messageErreurMdp = '';
+      },
+      error: () => {
+        this.messageErreurMdp = 'Ancien mot de passe incorrect.';
+      }
+    });
+  }
+
+  supprimerCompte(): void {
+    this.userService.deleteUser(this.userId!).subscribe({
+      next: () => {
+        localStorage.removeItem('token');
+        this.router.navigate(['/connexion']);
+      },
+      error: () => {
+        this.messageErreur = 'Erreur lors de la suppression du compte.';
+        this.confirmerSuppression = false;
+      }
+    });
+  }
 }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { UserResponse } from '../models/user-response.model';
+import { UpdateUserRequest } from '../models/update-user-request.model';
+import { UserUpdateResponse } from '../models/user-update-response.model';
+
+@Injectable({ providedIn: 'root' })
+export class UserService {
+
+  private apiUrl = 'http://localhost:8080/api/users';
+
+  constructor(private http: HttpClient) {}
+
+  // Récupère le profil de l'utilisateur connecté via le token JWT (géré par l'intercepteur)
+  getMe(): Observable<UserResponse> {
+    return this.http.get<UserResponse>(`${this.apiUrl}/my`);
+  }
+
+  getUser(id: number): Observable<UserResponse> {
+    return this.http.get<UserResponse>(`${this.apiUrl}/${id}`);
+  }
+
+  // Plus d'id dans l'URL — le back identifie l'utilisateur via le Principal (JWT)
+  // Retourne un nouveau token si l'email a changé
+  updateUser(data: UpdateUserRequest): Observable<UserUpdateResponse> {
+    return this.http.put<UserUpdateResponse>(`${this.apiUrl}`, data);
+  }
+
+  deleteUser(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/${id}`);
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -45,7 +45,7 @@
     --text-primary:    #e2e8f0;
     --text-secondary:  #cbd5e1;
     --text-label:      #cbd5e1;
-    --text-muted: #5e718c;
+    --text-muted:      #94a3b8;
     --text-cg:         #94a3b8;
 
     --border-input:    #3d3d3d;


### PR DESCRIPTION
- Ajout page profil : affichage, édition, changement de mot de passe, suppression de compte
- Ajout GET /api/users/my pour récupérer le profil via JWT sans décoder le token
- Fix mise à jour du token JWT après changement d'email (évite l'invalidation de session)
- Ajout <form (ngSubmit)> sur les pages connexion et inscription
- Fix autocomplete et intercepteur HTTP (exclusion des routes /auth/)
- Fix couleurs dark mode sur catalogue (input, select, pagination)
- Amélioration espacement formulaires auth